### PR TITLE
Store msclInternalNode as a std::unique_ptr<mscl::InertialNode>

### DIFF
--- a/ros_mscl/include/ros_mscl/microstrain_3dm.h
+++ b/ros_mscl/include/ros_mscl/microstrain_3dm.h
@@ -244,7 +244,7 @@ namespace Microstrain
   void print_packet_stats();
 
   // Variables/fields
-  mscl::InertialNode *msclInertialNode;
+  std::unique_ptr<mscl::InertialNode> msclInertialNode;
 
   //Packet Counters (valid, timeout, and checksum errors)
   uint32_t filter_valid_packet_count_;

--- a/ros_mscl/include/ros_mscl/microstrain_diagnostic_updater.h
+++ b/ros_mscl/include/ros_mscl/microstrain_diagnostic_updater.h
@@ -12,7 +12,7 @@ namespace ros_mscl
   class RosDiagnosticUpdater : private diagnostic_updater::Updater
   {
   public:
-    RosDiagnosticUpdater(mscl::InertialNode *device);
+    RosDiagnosticUpdater();
 
     void generalDiagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);
     void packetDiagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat);

--- a/ros_mscl/src/microstrain_diagnostic_updater.cpp
+++ b/ros_mscl/src/microstrain_diagnostic_updater.cpp
@@ -9,7 +9,7 @@
 namespace ros_mscl
 {
 
-RosDiagnosticUpdater::RosDiagnosticUpdater(mscl::InertialNode *device)
+RosDiagnosticUpdater::RosDiagnosticUpdater()
 {
   setHardwareID("unknown");
   add("general", this, &RosDiagnosticUpdater::generalDiagnostics);


### PR DESCRIPTION
Store the mscl::InertialNode as a std::unique_ptr, and remove unused variable from diagnostic updater

Signed-off-by: Hunter L. Allen <hunter.allen@ghostrobotics.io>

---

The original implementation makes a pointer to a stack object which it uses throughout the class. It's probably safer to heap allocate the node and store it as a `std::unique_ptr`.