### PR TITLE
Added support for gps_correlation_timestamp packet

### DIFF
--- a/ros_mscl/CMakeLists.txt
+++ b/ros_mscl/CMakeLists.txt
@@ -36,6 +36,8 @@ add_message_files(
   filter_heading_msg.msg
   filter_heading_state_msg.msg
   rtk_status_msg.msg
+  GpsCorrelationTimestamp.msg
+  GpsCorrelationTimestampStamped.msg
 )
 
 add_service_files(

--- a/ros_mscl/include/ros_mscl/microstrain_3dm.h
+++ b/ros_mscl/include/ros_mscl/microstrain_3dm.h
@@ -50,6 +50,7 @@
 #include "ros_mscl/filter_status_msg.h"
 #include "ros_mscl/filter_heading_msg.h"
 #include "ros_mscl/filter_heading_state_msg.h"
+#include "ros_mscl/GpsCorrelationTimestampStamped.h"
 #include "ros_mscl/SetAccelBias.h"
 #include "ros_mscl/GetAccelBias.h"
 #include "ros_mscl/SetGyroBias.h"
@@ -313,6 +314,7 @@ namespace Microstrain
   //IMU Publishers
   ros::Publisher m_imu_pub;
   ros::Publisher m_mag_pub;
+  ros::Publisher m_gps_corr_pub;
 
   //GNSS Publishers
   ros::Publisher m_gnss_pub[NUM_GNSS];
@@ -342,6 +344,7 @@ namespace Microstrain
   //IMU Messages
   sensor_msgs::Imu           m_imu_msg;
   sensor_msgs::MagneticField m_mag_msg;
+  ros_mscl::GpsCorrelationTimestampStamped m_gps_corr_msg;
 
   //GNSS Messages
   sensor_msgs::NavSatFix     m_gnss_msg[NUM_GNSS];
@@ -374,6 +377,7 @@ namespace Microstrain
   
   //Publish data flags
   bool m_publish_imu;
+  bool m_publish_gps_corr;
   bool m_publish_gnss[NUM_GNSS];
   bool m_publish_filter;
   bool m_publish_rtk;

--- a/ros_mscl/launch/microstrain.launch
+++ b/ros_mscl/launch/microstrain.launch
@@ -85,6 +85,11 @@
     <rosparam param="imu_linear_cov">      [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]</rosparam>
     <rosparam param="imu_angular_cov">     [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]</rosparam>
 
+    <!-- If enabled, this message can be used to validate time IMU time syncronzation with gps -->
+    <!-- It is most useful when using an external timesource and external PPS-->
+    <!-- (see: filter_enable_external_gps_time_update) -->
+    <param name="publish_gps_corr"  value="false" type="bool" />
+
 
     <!-- ****************************************************************** -->
     <!-- GNSS Settings (only applicable for devices with GNSS) -->

--- a/ros_mscl/msg/GpsCorrelationTimestamp.msg
+++ b/ros_mscl/msg/GpsCorrelationTimestamp.msg
@@ -1,0 +1,6 @@
+float64 gps_tow
+uint16 gps_week_number
+uint16 timestamp_flags
+uint16 TIMESTAMP_FLAG_PPS_GOOD      = 1  #0b001
+uint16 TIMESTAMP_FLAG_GPS_REFRESH   = 2  #0b010
+uint16 TIMESTAMP_FLAG_GPS_INITALIZED= 4  #0b100

--- a/ros_mscl/msg/GpsCorrelationTimestampStamped.msg
+++ b/ros_mscl/msg/GpsCorrelationTimestampStamped.msg
@@ -1,0 +1,3 @@
+Header header
+GpsCorrelationTimestamp gps_cor
+

--- a/ros_mscl/src/microstrain_3dm.cpp
+++ b/ros_mscl/src/microstrain_3dm.cpp
@@ -57,6 +57,7 @@ Microstrain::Microstrain()
   m_filter_frame_id = "filter_frame";
   m_filter_child_frame_id = "filter_child_frame";
   m_publish_imu = true;
+  m_publish_gps_corr = true;
   m_gps_leap_seconds = 18.0;
   m_publish_gnss[GNSS1_ID]= true;
   m_publish_gnss[GNSS2_ID]= true;
@@ -179,6 +180,7 @@ void Microstrain::run()
 
   //IMU
   private_nh.param("publish_imu",           m_publish_imu, true);
+  private_nh.param("publish_gps_corr",      m_publish_gps_corr, true);
   private_nh.param("imu_data_rate",         m_imu_data_rate, 10);
   private_nh.param("imu_frame_id",          m_imu_frame_id, std::string("sensor_ned"));
   private_nh.param("imu_orientation_cov",   m_imu_orientation_cov, default_matrix);
@@ -899,6 +901,13 @@ void Microstrain::run()
       m_imu_pub = node.advertise<sensor_msgs::Imu>("imu/data", 100);
     }
 
+
+    if(m_publish_imu && m_publish_gps_corr)
+    {
+      ROS_INFO("Publishing IMU GPS correlation timestamp.");
+      m_gps_corr_pub = node.advertise<ros_mscl::GpsCorrelationTimestampStamped>("gps_corr", 100);
+    }
+
     //If the device has a magnetometer, publish relevant topics
     if(m_publish_imu && m_inertial_device->features().supportsCommand(mscl::MipTypes::Command::CMD_MAG_HARD_IRON_OFFSET))
     {
@@ -1393,9 +1402,10 @@ void Microstrain::parse_imu_packet(const mscl::MipDataPacket &packet)
   m_imu_msg.header.frame_id = m_imu_frame_id;
   
   //Magnetometer timestamp
-  m_mag_msg.header.seq      = m_imu_msg.header.seq;
-  m_mag_msg.header.stamp    = m_imu_msg.header.stamp;
-  m_mag_msg.header.frame_id = m_imu_msg.header.frame_id;
+  m_mag_msg.header      = m_imu_msg.header;
+
+  //GPS correlation timestamp headder
+  m_gps_corr_msg.header = m_imu_msg.header;
 
   //Data present flags
   bool has_accel = false;
@@ -1407,8 +1417,9 @@ void Microstrain::parse_imu_packet(const mscl::MipDataPacket &packet)
   const mscl::MipDataPoints &points = packet.data();
 
   //Loop over the data elements and map them
-  for(mscl::MipDataPoint point : points)
+  for(auto point_iter = points.begin(); point_iter != points.end(); point_iter++)
   {
+    auto point = *point_iter;
     switch(point.field())
     {
     //Scaled Accel
@@ -1488,6 +1499,19 @@ void Microstrain::parse_imu_packet(const mscl::MipDataPacket &packet)
         m_imu_msg.orientation.w = quaternion.as_floatAt(0);
       }
     }break;
+
+    //GPS Corr
+    case mscl::MipTypes::ChannelField::CH_FIELD_SENSOR_GPS_CORRELATION_TIMESTAMP:
+    {
+      // for some reason point.qualifier() == mscl::MipTypes::CH_WEEK_NUMBER and
+      // point.qualifier() == mscl::MipTypes::CH_FLAGS always returned false so I used
+      // an iterator and manually incremented it to access all the elements
+      m_gps_corr_msg.gps_cor.gps_tow = point_iter->as_double();
+      point_iter++;
+      m_gps_corr_msg.gps_cor.gps_week_number = point_iter->as_uint16();
+      point_iter++;
+      m_gps_corr_msg.gps_cor.timestamp_flags = point_iter->as_uint16();
+    }break;
     }
   }
 
@@ -1511,6 +1535,9 @@ void Microstrain::parse_imu_packet(const mscl::MipDataPacket &packet)
 
   //Publish
   m_imu_pub.publish(m_imu_msg);
+
+  if(m_publish_gps_corr)
+    m_gps_corr_pub.publish(m_gps_corr_msg);
 
   if(has_mag)
     m_mag_pub.publish(m_mag_msg);

--- a/ros_mscl/src/microstrain_3dm.cpp
+++ b/ros_mscl/src/microstrain_3dm.cpp
@@ -57,7 +57,7 @@ Microstrain::Microstrain()
   m_filter_frame_id = "filter_frame";
   m_filter_child_frame_id = "filter_child_frame";
   m_publish_imu = true;
-  m_publish_gps_corr = true;
+  m_publish_gps_corr = false;
   m_gps_leap_seconds = 18.0;
   m_publish_gnss[GNSS1_ID]= true;
   m_publish_gnss[GNSS2_ID]= true;
@@ -180,7 +180,7 @@ void Microstrain::run()
 
   //IMU
   private_nh.param("publish_imu",           m_publish_imu, true);
-  private_nh.param("publish_gps_corr",      m_publish_gps_corr, true);
+  private_nh.param("publish_gps_corr",      m_publish_gps_corr, false);
   private_nh.param("imu_data_rate",         m_imu_data_rate, 10);
   private_nh.param("imu_frame_id",          m_imu_frame_id, std::string("sensor_ned"));
   private_nh.param("imu_orientation_cov",   m_imu_orientation_cov, default_matrix);


### PR DESCRIPTION
We are using a GX5_25 with an external GPS with an external PPS input. I experimented with this a bit through my own mscl driver https://bitbucket.org/croman_and_the_barbarians/mscl_ros/src/master/ . The only way I have found to check if the external pps input is working was to look at the gps_correlation_timestamp message.

The gps_correlation_timestamp was already listed under ahrsChannels so I added a corresponding message, IMU message switch case and publisher.

The published message, GpsCorrelationTimestampStamped, has an attached ROS header so that it can be easily synchronized with the other imu related messages (IMU/MAG). If recorded, it also allows you to check in post that the GPS time was properly converted to UTC (ROS time).