### PR TITLE
redefined g according to the spec

### DIFF
--- a/ros_mscl/include/ros_mscl/microstrain_3dm.h
+++ b/ros_mscl/include/ros_mscl/microstrain_3dm.h
@@ -114,6 +114,8 @@
 #define SECS_PER_WEEK (60L*60*24*7)
 #define UTC_GPS_EPOCH_DUR (315964800)
 
+#define USTRAIN_G 9.80665  // from section 5.1.1 in https://www.microstrain.com/sites/default/files/3dm-gx5-25_dcp_manual_8500-0065_reference_document.pdf
+
 //Macro to cause Sleep call to behave as it does for windows
 #define Sleep(x) usleep(x*1000.0)
 

--- a/ros_mscl/src/microstrain_3dm.cpp
+++ b/ros_mscl/src/microstrain_3dm.cpp
@@ -1419,15 +1419,15 @@ void Microstrain::parse_imu_packet(const mscl::MipDataPacket &packet)
       // Stuff into ROS message - acceleration in m/s^2
       if(point.qualifier() == mscl::MipTypes::CH_X)
       {
-        m_imu_msg.linear_acceleration.x = 9.81 * point.as_float();
+        m_imu_msg.linear_acceleration.x = USTRAIN_G * point.as_float();
       }
       else if(point.qualifier() == mscl::MipTypes::CH_Y)
       {
-        m_imu_msg.linear_acceleration.y = 9.81 * point.as_float();
+        m_imu_msg.linear_acceleration.y = USTRAIN_G * point.as_float();
       }
       else if(point.qualifier() == mscl::MipTypes::CH_Z)
       {
-        m_imu_msg.linear_acceleration.z = 9.81 * point.as_float();
+        m_imu_msg.linear_acceleration.z = USTRAIN_G * point.as_float();
       }
     }break;
 


### PR DESCRIPTION
Gravitational acceleration constant, g, was set to 9.81 in parse_imu_packet().   The microstrain documentation defines it as 9.80665 per the ISO 80000 spec (https://www.microstrain.com/sites/default/files/3dm-gx5-25_dcp_manual_8500-0065_reference_document.pdf sec. 5.1.1).  


This can degrade imu performance in inertial navigation. 