### PR TITLE
Make frame IDs configurable

### DIFF
--- a/ros_mscl/launch/microstrain.launch
+++ b/ros_mscl/launch/microstrain.launch
@@ -2,35 +2,38 @@
 <launch>
 
   <!-- Standalone example launch file for GX3, GX4, GX/CX5, RQ1 and GQ7 series devices-->
-  <!-- Note: Feature support is device-dependent and some of the following settings may have no affect on your device. --> 
+  <!-- Note: Feature support is device-dependent and some of the following settings may have no affect on your device. -->
      <!--  Please consult your device's documentation for supported features -->
 
   <!-- Declare arguments with default values -->
-  <arg name="name"        default = "gx5" />
-  <arg name="port"        default = "/dev/ttyACM0" />
-  <arg name="baudrate"    default = "115200" />
-  <arg name="debug"       default = "false" />
-  <arg name="diagnostics" default = "true" />
-
+  <arg name="name"            default = "gx5" />
+  <arg name="port"            default = "/dev/ttyACM0" />
+  <arg name="baudrate"        default = "115200" />
+  <arg name="debug"           default = "false" />
+  <arg name="diagnostics"     default = "true" />
+  <arg name="imu_frame_id"    default = "sensor" />
+  <arg name="gnss1_frame_id"  default = "gnss1_antenna_wgs84" />
+  <arg name="gnss2_frame_id"  default = "gnss2_antenna_wgs84" />
+  <arg name="filter_frame_id" default = "sensor_wgs84" />
 
   <!-- ****************************************************************** -->
   <!-- Microstrain sensor node -->
   <!-- ****************************************************************** -->
-    
+
   <node name="ros_mscl_node" pkg="ros_mscl" type="ros_mscl_node" output="screen" ns="$(arg name)">
 
     <!-- ****************************************************************** -->
     <!-- General Settings -->
     <!-- ****************************************************************** -->
-    
+
     <param name="port"     value="$(arg port)"     type="str" />
     <param name="baudrate" value="$(arg baudrate)" type="int" />
-    
+
     <!-- Controls if the driver outputs data with-respect-to ENU frame
           false - position, velocity, and orientation are WRT the NED frame (native device frame)
           true  - position, velocity, and orientation are WRT the ENU frame
      -->
-     
+
     <param name="use_enu_frame" value="false" type="bool" />
 
 
@@ -38,34 +41,34 @@
           false - The driver will ignore the settings below and use the device's current settings
           true  - Overwrite the current device settings with those listed below
      -->
-     
-    <param name="device_setup" value="true" type="bool" />
-    
 
-    <!-- Controls if the driver-defined settings are saved 
+    <param name="device_setup" value="true" type="bool" />
+
+
+    <!-- Controls if the driver-defined settings are saved
           false - Do not save the settings
           true  - Save the settings in the device's non-volatile memory
      -->
-     
+
     <param name="save_settings" value="false" type="bool" />
-    
-    <!-- Controls if the driver uses the device generated timestamp (if available) for timestamping messages 
+
+    <!-- Controls if the driver uses the device generated timestamp (if available) for timestamping messages
           false - Use PC received time for timestamping
           true  - Use device generated timestamp
      -->
-     
+
     <param name="use_device_timestamp" value="false" type="bool" />
 
     <!-- Controls if the driver creates a raw binary file
           false - Do not create the file
           true  - Create the file
 
-          Notes: 1) The filename will have the following format - 
+          Notes: 1) The filename will have the following format -
                     model_number "_" serial_number "_" datetime (year_month_day_hour_minute_sec) ".bin"
                     example: "3DM-GX5-45_6251.00001_20_12_01_01_01_01.bin"
                  2) This file is useful for getting support from the manufacturer
      -->
-     
+
     <param name="raw_file_enable" value="false" type="bool" />
 
 
@@ -82,15 +85,15 @@
     <!-- The directory to store the raw data file (no trailing '/')-->
 
     <param name="raw_file_directory" value="/home/your_name" type="str" />
- 
+
 
     <!-- ****************************************************************** -->
     <!-- IMU Settings -->
     <!-- ****************************************************************** -->
-    
-    <param name="publish_imu"   value="true"     type="bool" />
-    <param name="imu_data_rate" value="100"      type="int" />
-    <param name="imu_frame_id"  value="sensor"   type="str" />
+
+    <param name="publish_imu"   value="true"                  type="bool" />
+    <param name="imu_data_rate" value="100"                   type="int" />
+    <param name="imu_frame_id"  value="$(arg imu_frame_id)"   type="str" />
 
     <!-- Static IMU message covariance values (the device does not generate these) -->
     <!-- Since internally these are std::vector we need to use the rosparam tags -->
@@ -107,22 +110,22 @@
     <!-- ****************************************************************** -->
     <!-- GNSS Settings (only applicable for devices with GNSS) -->
     <!-- ****************************************************************** -->
-    
-    <param name="publish_gnss1"   value="true" type="bool" />
-    <param name="gnss1_data_rate" value="2"    type="int" />
-    <param name="gnss1_frame_id"  value="gnss1_antenna_wgs84" type="str" />
+
+    <param name="publish_gnss1"   value="true"                  type="bool" />
+    <param name="gnss1_data_rate" value="2"                     type="int" />
+    <param name="gnss1_frame_id"  value="$(arg gnss1_frame_id)" type="str" />
 
     <!-- Antenna #1 lever arm offset vector
          For GQ7 - in the vehicle frame wrt IMU origin (meters)
-         For all other models - in the IMU frame wrt IMU origin (meters) 
-         Note: Make this as accurate as possible for good performance 
+         For all other models - in the IMU frame wrt IMU origin (meters)
+         Note: Make this as accurate as possible for good performance
      -->
     <rosparam param="gnss1_antenna_offset"> [0.0, -0.7, -1.0]</rosparam>
 
     <!-- GNSS2 settings are only applicable for multi-GNSS systems (e.g. GQ7) -->
-    <param name="publish_gnss2"   value="true" type="bool" />
-    <param name="gnss2_data_rate" value="2"    type="int" />
-    <param name="gnss2_frame_id"  value="gnss2_antenna_wgs84" type="str" />
+    <param name="publish_gnss2"   value="true"                  type="bool" />
+    <param name="gnss2_data_rate" value="2"                     type="int" />
+    <param name="gnss2_frame_id"  value="$(arg gnss2_frame_id)" type="str" />
 
     <!-- Antenna #2 lever arm offset vector (In the vehicle frame wrt IMU origin (meters) )-->
     <!--Note: Make this as accurate as possible for good performance -->
@@ -131,17 +134,17 @@
 
     <!-- (GQ7 Only) Enable RTK dongle interface -->
     <param name="rtk_dongle_enable" value="false"    type="bool" />
- 
+
     <!-- ****************************************************************** -->
     <!-- Kalman Filter Settings (only applicable for devices with a Kalman Filter) -->
     <!-- ****************************************************************** -->
-    
-    <param name="publish_filter"       value="true"         type="bool" />
-    <param name="filter_data_rate"     value="10"           type="int" />
-    <param name="filter_frame_id"      value="sensor_wgs84" type="str" />
 
-    <!-- Sensor2vehicle frame transformation selector 
-         0 = None, 1 = Euler Angles, 2 - matrix, 3 - quaternion 
+    <param name="publish_filter"       value="true"                   type="bool" />
+    <param name="filter_data_rate"     value="10"                     type="int" />
+    <param name="filter_frame_id"      value="$(arg filter_frame_id)" type="str" />
+
+    <!-- Sensor2vehicle frame transformation selector
+         0 = None, 1 = Euler Angles, 2 - matrix, 3 - quaternion
          Notes: These are different ways of setting the same parameter in the device.
                 The different options are provided as a convenience.
                 Support for matrix and quaternion options is firmware version dependent (Quaternion not currently supported on GQ7)
@@ -152,7 +155,7 @@
     <rosparam param="filter_sensor2vehicle_frame_transformation_euler">      [0.0, 0.0, 0.0]</rosparam>
     <rosparam param="filter_sensor2vehicle_frame_transformation_matrix">     [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]</rosparam>
     <rosparam param="filter_sensor2vehicle_frame_transformation_quaternion"> [0.0, 0.0, 0.0, 1.0]</rosparam>
- 
+
 
      <!-- Controls if the Kalman filter is reset after the settings are configured-->
     <param name="filter_reset_after_config" value="true" type="bool" />
@@ -169,18 +172,18 @@
 
     <!-- (GX5 and previous,-45 models only) Dynamics Mode 1 = Portable (default), 2 = Automotive, 3 = Airborne (<2Gs), 4 = Airborne High G (<4Gs) -->
     <param name="filter_dynamics_mode" value="1" type="int" />>
-        
+
     <!-- ZUPT control -->
     <param name="filter_velocity_zupt_topic" value="/moving_vel" type="str" />
     <param name="filter_angular_zupt_topic"  value="/moving_ang" type="str" />
     <param name="filter_velocity_zupt"       value="true" type="bool" />
     <param name="filter_angular_zupt"        value="true" type="bool" />
 
-    <!-- (GQ7 full support, GX5-45 limited support) Adaptive filter settings 
+    <!-- (GQ7 full support, GX5-45 limited support) Adaptive filter settings
           Adaptive level: 0 - off, 1 - Conservative, 2 = Moderate (default), 3 = agressive
-          Time limit: Max duration of measurement rejection prior to recovery, in milliseconds - default = 15000 
+          Time limit: Max duration of measurement rejection prior to recovery, in milliseconds - default = 15000
      -->
-    
+
     <param name="filter_adaptive_level"         value="2" type="int" />
     <param name="filter_adaptive_time_limit_ms" value="15000" type="int" />
 
@@ -192,7 +195,7 @@
     <param name="filter_enable_magnetometer_aiding"     value="false" type="bool" />
     <param name="filter_enable_external_heading_aiding" value="false" type="bool" />
 
-    <!--  External GPS Time Update Control 
+    <!--  External GPS Time Update Control
           Notes:    filter_external_gps_time_topic should publish at no more than 1 Hz.
                     gps_leap_seconds should be updated to reflect the current number
                     of leap seconds.
@@ -203,14 +206,14 @@
 
 
     <!--  (GQ7 only) GPIO Configuration
-          Notes:    For information on possible configurations and specific pin options, 
+          Notes:    For information on possible configurations and specific pin options,
                     refer to the MSCL MipNodeFeatures command, supportedGpioConfigurations.
 
-          GPIO Pins = 
-          1 - GPIO1 (primary port pin 7) - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder 
-          2 - GPIO2 (primary port pin 9) - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder 
-          3 - GPIO3 (aux port pin 7)     - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder 
-          4 - GPIO4 (aux port pin 9)     - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder 
+          GPIO Pins =
+          1 - GPIO1 (primary port pin 7) - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder
+          2 - GPIO2 (primary port pin 9) - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder
+          3 - GPIO3 (aux port pin 7)     - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder
+          4 - GPIO4 (aux port pin 9)     - Features = 0 - Unused, 1 - GPIO, 2 - PPS, 3 - Encoder
 
           Feature:
           0 - Unused   - Behaviors = 0 - unused
@@ -219,22 +222,22 @@
           3 - Encoder  - Behaviors = 0 - unused, 1 - enc A, 2 - enc B
 
           GPIO Behavior:
-          0 - Unused       
-          1 - Input        
-          2 - Output Low   
-          3 - Output High  
+          0 - Unused
+          1 - Input
+          2 - Output Low
+          3 - Output High
 
           PPS Behavior:
-          0 - Unused 
-          1 - Input   
-          2 - Output  
-          
-          Encoder Behavior:
-          0 - Unused 
-          1 - Encoder A 
-          2 - Encoder B   
+          0 - Unused
+          1 - Input
+          2 - Output
 
-          Pin Mode Bitfield: 
+          Encoder Behavior:
+          0 - Unused
+          1 - Encoder A
+          2 - Encoder B
+
+          Pin Mode Bitfield:
           1 - open drain
           2 - pulldown
           4 - pullup
@@ -242,15 +245,15 @@
     <param name="gpio1_feature"     value="0" type="int" />
     <param name="gpio1_behavior"    value="0" type="int" />
     <param name="gpio1_pin_mode"    value="0" type="int" />
-    
+
     <param name="gpio2_feature"     value="0" type="int" />
     <param name="gpio2_behavior"    value="0" type="int" />
     <param name="gpio2_pin_mode"    value="0" type="int" />
-    
+
     <param name="gpio3_feature"     value="0" type="int" />
     <param name="gpio3_behavior"    value="0" type="int" />
     <param name="gpio3_pin_mode"    value="0" type="int" />
-    
+
     <param name="gpio4_feature"     value="0" type="int" />
     <param name="gpio4_behavior"    value="0" type="int" />
     <param name="gpio4_pin_mode"    value="0" type="int" />
@@ -258,18 +261,18 @@
     <param name="gpio_config"       value="false" type="bool" />
 
     <!-- (GQ7 only) Filter Initialization control
-  
-         Init Condition source = 
-         0 - auto pos, vel, attitude (default) 
+
+         Init Condition source =
+         0 - auto pos, vel, attitude (default)
          1 - auto pos, vel, roll, pitch, manual heading
          2 - auto pos, vel, manual attitude
          3 - manual pos, vel, attitude
-     
-         Auto-Heading alignment selector (note this is a bitfield, you can use more than 1 source) = 
-         Bit 0 - Dual-antenna GNSS 
+
+         Auto-Heading alignment selector (note this is a bitfield, you can use more than 1 source) =
+         Bit 0 - Dual-antenna GNSS
          Bit 1 - GNSS kinematic (requires motion, e.g. a GNSS velocity)
-         Bit 2 - Magnetometer 
-       
+         Bit 2 - Magnetometer
+
          Reference frame =
          1 - WGS84 Earth-fixed, earth centered (ECEF) position, velocity, attitude
          2 - WGS84 Latitude, Longitude, height above ellipsoid position, NED velocity and attitude
@@ -278,7 +281,7 @@
     <param name="filter_init_condition_src"              value="0"     type="int" />
     <param name="filter_auto_heading_alignment_selector" value="1"     type="int" />
     <param name="filter_init_reference_frame"            value="2"     type="int" />
-    <rosparam param="filter_init_position">   [0.0, 0.0, 0.0]</rosparam>    
+    <rosparam param="filter_init_position">   [0.0, 0.0, 0.0]</rosparam>
     <rosparam param="filter_init_velocity">   [0.0, 0.0, 0.0]</rosparam>
     <rosparam param="filter_init_attitude">   [0.0, 0.0, 0.0]</rosparam>
 
@@ -290,36 +293,36 @@
          Reference position - Units provided by reference frame (ECEF - meters, LLH - deg, deg, meters)
          Note: prior to firmware version 1.0.06 this command will fail for non-positive heights.  1.0.06 fixes this)
      -->
-    
+
     <param name="publish_relative_position"         value="false" type="bool" />
     <param name="filter_relative_position_frame"    value="2"  type="int" />
-    <rosparam param="filter_relative_position_ref"> [0, 0, 0.01]</rosparam>    
+    <rosparam param="filter_relative_position_ref"> [0, 0, 0.01]</rosparam>
 
     <!-- (GQ7 only) Speed Lever Arm Configuration
          Lever Arm - In vehicle reference frame (meters)
      -->
-    
-    <rosparam param="filter_speed_lever_arm"> [0.0, 0.0, 0.0]</rosparam>    
 
-    <!-- (GQ7 only) Wheeled Vehicle Constraint Control 
-    
-          Note: When enabled, the filter uses the assumption that velocity is constrained to the primary vehicle axis. 
+    <rosparam param="filter_speed_lever_arm"> [0.0, 0.0, 0.0]</rosparam>
+
+    <!-- (GQ7 only) Wheeled Vehicle Constraint Control
+
+          Note: When enabled, the filter uses the assumption that velocity is constrained to the primary vehicle axis.
                 By convention, the primary vehicle axis is the vehicle X-axis
      -->
-    
+
     <param name="filter_enable_wheeled_vehicle_constraint" value="false"  type="bool" />
 
-    <!-- (GQ7 only) Vertical Gyro Constraint Control 
-    
-          Note: When enabled and no valid GNSS measurements are available, the filter uses the accelerometers to track 
+    <!-- (GQ7 only) Vertical Gyro Constraint Control
+
+          Note: When enabled and no valid GNSS measurements are available, the filter uses the accelerometers to track
                 pitch and roll under the assumption that the sensor platform is not undergoing linear acceleration.
                 This constraint is useful to maintain accurate pitch and roll during GNSS signal outages.
      -->
-    
+
     <param name="filter_enable_vertical_gyro_constraint" value="false"  type="bool" />
-    
-    <!-- (GQ7 only) GNSS Antenna Calibration Control 
-    
+
+    <!-- (GQ7 only) GNSS Antenna Calibration Control
+
          Note: When enabled, the filter will enable lever arm error tracking, up to the maximum offset specified in meters.
      -->
 
@@ -335,7 +338,7 @@
           7 - GPIO 4 (provided by external source if supported)
      -->
     <param name="filter_pps_source" value="1" type="int" />
-    
+
     <param name="filter_enable_gnss_antenna_cal"     value="false" type="bool" />
     <param name="filter_gnss_antenna_cal_max_offset" value="0.1"   type="double" />
   </node>
@@ -344,7 +347,7 @@
   <!-- ****************************************************************** -->
   <!-- Diagnostics -->
   <!-- ****************************************************************** -->
-    
+
   <group if="$(arg diagnostics)">
 
     <!-- Diagnostic Aggregator for robot monitor usage -->
@@ -357,7 +360,7 @@
   <!-- ****************************************************************** -->
   <!-- Set the debug level to debug -->
   <!-- ****************************************************************** -->
- 
+
   <group if="$(arg debug)">
     <env name="ROSCONSOLE_CONFIG_FILE"
        value="$(find ros_mscl)/config/custom_rosconsole.conf"/>


### PR DESCRIPTION
Add launch args for all of the frame ids to allow them to be modified.  Keep the old static values as the defaults.

This makes it easier to launch the node using frames that are already in a robot's URDF (e.g. `imu_link` or `gps_link`), and allows multiple sensors of the same kind to be added, each using distinct links.