### PR TITLE
Add tf2_geometry_msgs as a dependency

### DIFF
--- a/ros_mscl/CMakeLists.txt
+++ b/ros_mscl/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   tf2
   tf2_ros
+  tf2_geometry_msgs
   diagnostic_updater
 	mscl_msgs
 )
@@ -62,6 +63,7 @@ catkin_package(
     cmake_modules
     tf2
     tf2_ros
+    tf2_geometry_msgs
     std_msgs
     std_srvs
     geometry_msgs

--- a/ros_mscl/package.xml
+++ b/ros_mscl/package.xml
@@ -22,6 +22,7 @@
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>mscl_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>roslint</build_depend>


### PR DESCRIPTION
`microstrain_3dm.h` includes `tf2_geometry_msgs/tf2_geometry_msgs.h`, but this package is not explicitly set as a dependency, which can cause build failures in some environments.