### PR TITLE
Explicitly name the mscl_msgs package

### DIFF
--- a/mscl_msgs/CMakeLists.txt
+++ b/mscl_msgs/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-
-get_filename_component(PACKAGE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-message("Creating Package: ${PACKAGE_NAME}")
-
-project(${PACKAGE_NAME})  ## this package name is the name of the directory this cmake file is in
+project(mscl_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
 


### PR DESCRIPTION
Some parallelized build systems extract each individual package into arbitrarily-named folders, so using the parent folder name to get the package name breaks the build.  This occurs especially when building .deb packages out of the ROS packages.

Explicitly naming the package should prevent this problem.