### PR TITLE
Feature/ros2 rtcm sub

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -7,7 +7,9 @@ ENV DEBIAN_FRONTEND="noninteractive"
 RUN set -ex \
     && apt-get update && apt-get install -y \
         gdb \
-        git
+        git \
+        vim \
+        bash-completion
 
 # Add a user that will be used when shelling into this container and allow them to use devices
 ARG USER_ID=1000
@@ -27,6 +29,8 @@ RUN set -ex \
 # Make the directory where we will mount all the files into and build a single time
 USER microstrain
 RUN echo "source /opt/ros/\${ROS_DISTRO}/setup.bash" >> ${HOME}/.bashrc
+RUN echo "source /usr/share/bash-completion/bash_completion" >> ${HOME}/.bashrc
+RUN echo "source /etc/bash_completion" >> ${HOME}/.bashrc
 RUN mkdir -p "${HOME}/catkin_ws/src"
 RUN mkdir -p "${HOME}/catkin_ws/build"
 RUN mkdir -p "${HOME}/catkin_ws/install"

--- a/.devcontainer/Makefile
+++ b/.devcontainer/Makefile
@@ -4,7 +4,7 @@
 version ?= latest
 docker ?= docker
 arch ?= amd64
-ros_version ?= noetic
+ros_version ?= galactic
 
 # Just set some directory values to support out of tree builds
 makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
@@ -13,14 +13,14 @@ project_dir := $(abspath $(docker_dir)/..)
 project_name := $(shell echo $(notdir $(project_dir)) | tr A-Z a-z)
 artifacts_dir := $(docker_dir)/.artifacts/$(arch)-$(ros_version)
 build_dir := $(artifacts_dir)/build
-devel_dir := $(artifacts_dir)/devel
-docker_catkin_root := /home/microstrain
+install_dir := $(artifacts_dir)/install
+docker_catkin_root := /home/microstrain/catkin_ws
 docker_catkin_src_dir := $(docker_catkin_root)/src
 docker_catkin_build_dir := $(docker_catkin_root)/build
-docker_catkin_devel_dir := $(docker_catkin_root)/devel
+docker_catkin_install_dir := $(docker_catkin_root)/install
 
 # All of these directories have to exist before we can run most tasks
-dir_deps := $(artifacts_dir) $(build_dir) $(devel_dir)
+dir_deps := $(artifacts_dir) $(build_dir) $(install_dir)
 
 # Grab the user and group ID so that the files we create can be deleted and managed from the base system
 user_id := $(shell id -u)
@@ -29,22 +29,14 @@ group_id := $(shell id -g)
 # Set up some variables for the docker build
 dev_dockerfile := $(docker_dir)/Dockerfile.dev
 deploy_dockerfile := $(docker_dir)/Dockerfile.deploy
-build_args := --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --build-arg ARCH=$(arch) --build-arg USER_ID=$(user_id) --build-arg GROUP_ID=$(group_id)
+build_args := --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --build-arg ARCH=$(arch) --build-arg ROS_VERSION=$(ros_version) --build-arg USER_ID=$(user_id) --build-arg GROUP_ID=$(group_id)
 run_args := -e http_proxy -e https_proxy -e no_proxy
-run_mounts := -v "$(project_dir):/tmp/$(project_name)_release_workspace" -v "$(project_dir)/ros_mscl:$(docker_catkin_src_dir)/ros_mscl" -v "$(project_dir)/mscl_msgs:$(docker_catkin_src_dir)/mscl_msgs" -v "$(project_dir)/Examples:$(docker_catkin_src_dir)/Examples" -v "$(build_dir):$(docker_catkin_build_dir)" -v "$(devel_dir):$(docker_catkin_devel_dir)"
+run_mounts := -v "$(project_dir):$(docker_catkin_src_dir)" -v "$(build_dir):$(docker_catkin_build_dir)" -v "$(install_dir):$(docker_catkin_install_dir)"
 dev_image_name := $(arch)/$(project_name)-dev:$(ros_version)
 deploy_image_name := $(arch)/$(project_name):$(ros_version)
 dev_image_artifact := $(artifacts_dir)/.image
 
 all: image
-
-image: $(dev_image_artifact) $(deploy_dockerfile)
-	@$(docker) build \
-		--build-arg DEV_IMAGE="$(dev_image_name)" \
-		-t $(deploy_image_name) \
-		-f $(deploy_dockerfile) \
-		$(build_args) \
-		$(project_dir)
 
 $(dev_image_artifact): $(dev_dockerfile) | $(dir_deps)
 	@$(docker) build \
@@ -61,10 +53,16 @@ build-shell: $(dev_image_artifact)
 		-v /dev:/dev \
 		--user "microstrain" \
 		-w $(docker_catkin_root) \
+		--net="host" \
 		--privileged \
+		--entrypoint="/bin/bash" \
 		$(run_args) \
 		$(run_mounts) \
-		$$(cat $<)
+		$$(cat $<) -c " \
+			sudo apt-get update; \
+			rosdep install --from-paths $(docker_catkin_src_dir) --ignore-src -r -y; \
+			/bin/bash; \
+		"
 
 $(artifacts_dir):
 	@mkdir -p $@
@@ -72,11 +70,11 @@ $(artifacts_dir):
 $(build_dir):
 	@mkdir -p $@
 
-$(devel_dir):
+$(install_dir):
 	@mkdir -p $@
 
 clean:
-	@rm -rf "$(build_dir)" "$(devel_dir)"
+	@rm -rf "$(build_dir)" "$(install_dir)"
 	@rm -f "$(dev_image_artifact)"
 	@docker ps -a | grep "$(project_name)" | grep "$(arch)" | grep "$(ros_version)" | tr -s " " | cut -d' ' -f1 | xargs docker rm -f || echo "No containers to remove"
 	@docker images | grep "$(project_name)" | grep "$(arch)" | grep "$(ros_version)" | tr -s " " | cut -d' ' -f1 | xargs docker rmi -f || echo "No images to remove"

--- a/microstrain_inertial_driver/CMakeLists.txt
+++ b/microstrain_inertial_driver/CMakeLists.txt
@@ -47,6 +47,8 @@ find_package(lifecycle_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(nmea_msgs REQUIRED)
+find_package(mavros_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -79,6 +81,8 @@ ament_export_dependencies(
     geometry_msgs
     sensor_msgs
     nav_msgs
+    nmea_msgs
+    mavros_msgs
     message_runtime
 		microstrain_inertial_msgs
 )
@@ -127,6 +131,8 @@ ament_target_dependencies(${PROJECT_NAME}
   sensor_msgs
   geometry_msgs
   nav_msgs
+  nmea_msgs
+  mavros_msgs
   tf2
   tf2_ros
   tf2_geometry_msgs

--- a/microstrain_inertial_driver/debian/udev
+++ b/microstrain_inertial_driver/debian/udev
@@ -2,6 +2,11 @@
 # Uncomment this line if you want the legacy rule which will set up a single link to /dev/microstrain. If more than one device is connected, this rule will get continuously overridden which is why it is commented out by default
 #SUBSYSTEM=="tty", SUBSYSTEMS=="usb", ATTRS{product}=="Lord Inertial Sensor", SYMLINK="microstrain", MODE="0666"
 
+# Convenience rule that will register a single device to /dev/microstrain_main, /dev/microstrain_aux, or /dev/microstrain_rtk.
+# This link will get continuously overridden if you have multiple devices, in which case you should use the symlinks below that will symlink by serial number
+SUBSYSTEM=="tty", ATTRS{idVendor}=="199b", ATTRS{idProduct}=="3065", PROGRAM="/bin/sh -c 'echo %s{serial} | sed s/^0000__.*/rtk/g | sed s/^0000.*/main/g | sed s/^2-00.*/aux/g'", SYMLINK+="microstrain_%c", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", PROGRAM="/bin/sh -c 'echo %s{serial} | sed s/^0000__.*/rtk/g | sed s/^0000.*/main/g | sed s/^2-00.*/aux/g'", SYMLINK+="microstrain_%c", MODE="0666"
+
 # Rule to create links for multiple different devices
-SUBSYSTEM=="tty", ATTRS{idVendor}=="199b", ATTRS{idProduct}=="3065", PROGRAM="/bin/sh -c 'echo \"%s{serial}\" | sed \"s/^0000__/rtk/g; s/^0000/main/g; s/^2-00/aux/g;\"'", SYMLINK+="microstrain_%c", MODE="0666"
-SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", PROGRAM="/bin/sh -c 'echo \"%s{serial}\" | sed \"s/^0000__/rtk/g; s/^0000/main/g; s/^2-00/aux/g;\"'", SYMLINK+="microstrain_%c", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="199b", ATTRS{idProduct}=="3065", PROGRAM="/bin/sh -c 'echo %s{serial} | sed s/^0000__/rtk/g | sed s/^0000/main/g | sed s/^2-00/aux/g'", SYMLINK+="microstrain_%c", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", PROGRAM="/bin/sh -c 'echo %s{serial} | sed s/^0000__/rtk/g | sed s/^0000/main/g | sed s/^2-00/aux/g'", SYMLINK+="microstrain_%c", MODE="0666"

--- a/microstrain_inertial_driver/include/microstrain_inertial_driver/microstrain_inertial_driver.h
+++ b/microstrain_inertial_driver/include/microstrain_inertial_driver/microstrain_inertial_driver.h
@@ -56,7 +56,8 @@ class Microstrain : public rclcpp_lifecycle::LifecycleNode, public MicrostrainNo
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State &prev_state);
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(const rclcpp_lifecycle::State &prev_state);
 
-  void parse_and_publish_wrapper();
+  void parse_and_publish_main_wrapper();
+  void parse_and_publish_aux_wrapper();
   void device_status_wrapper();
 
  private:

--- a/microstrain_inertial_driver/launch/microstrain_launch.py
+++ b/microstrain_inertial_driver/launch/microstrain_launch.py
@@ -12,6 +12,7 @@ def generate_launch_description():
             # Declare arguments with default values
             DeclareLaunchArgument('name',                  default_value='gx5'),
             DeclareLaunchArgument('port',                  default_value='/dev/ttyACM0'),
+            DeclareLaunchArgument('aux_port',              default_value='/dev/ttyACM1'),
             DeclareLaunchArgument('baudrate',              default_value='115200'),
             DeclareLaunchArgument('debug',                 default_value='False'),
             DeclareLaunchArgument('diagnostics',           default_value='False'),
@@ -22,6 +23,7 @@ def generate_launch_description():
             DeclareLaunchArgument('gnss2_frame_id',        default_value='gnss2_antenns_wgs84'),
             DeclareLaunchArgument('filter_frame_id',       default_value='sensor_wgs84'),
             DeclareLaunchArgument('filter_child_frame_id', default_value='sensor'),
+            DeclareLaunchArgument('nmea_frame_id',         default_value='nmea'),
             DeclareLaunchArgument('use_enu_frame',         default_value='False'),
 
            # ****************************************************************** 
@@ -39,8 +41,11 @@ def generate_launch_description():
                               # ****************************************************************** 
                               # General Settings 
                               # ****************************************************************** 
-                              
+
+                              # port is the main port that the device will communicate over. For all devices except the GQy, this is the only available port.
+                              # aux_port is only available for the GQ7 and is only needed when streaming RTCM corrections to the device from ROS, or if you want to publish NMEA sentences from this node
                               "port"        : LaunchConfiguration('port'),
+                              "aux_port"    : LaunchConfiguration('aux_port'),
                               "baudrate"    : LaunchConfiguration('baudrate'),
                               "debug"       : LaunchConfiguration('debug'),
                               "diagnostics" : LaunchConfiguration('diagnostics'),
@@ -55,6 +60,7 @@ def generate_launch_description():
                               "gnss2_frame_id"        : LaunchConfiguration('gnss2_frame_id'),
                               "filter_frame_id"       : LaunchConfiguration('filter_frame_id'),
                               "filter_child_frame_id" : LaunchConfiguration('filter_child_frame_id'),
+                              "nmea_frame_id"         : LaunchConfiguration('nmea_frame_id'),
 
                               # Waits for a configurable amount of time until the device exists
                               # If poll_max_tries is set to -1 we will poll forever until the device exists
@@ -157,6 +163,13 @@ def generate_launch_description():
 
                               # (GQ7 Only) Enable RTK dongle interface 
                               "rtk_dongle_enable" : False,
+
+                              # (GQ7 Only) Allow the user to send RTCM messages to this node, and stream those messages to the GQ7
+                              "subscribe_rtcm" : False,
+                              "rtcm_topic"     : "/rtcm",
+
+                              # (GQ7 Only) Send NMEA sentences from the aux port out on a ROS topic
+                              "publish_nmea"   : False,
 
                               # ****************************************************************** 
                               # Kalman Filter Settings (only applicable for devices with a Kalman Filter) 

--- a/microstrain_inertial_driver/package.xml
+++ b/microstrain_inertial_driver/package.xml
@@ -27,6 +27,8 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>nmea_msgs</depend>
+  <depend>mavros_msgs</depend>
   <depend>microstrain_inertial_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>lifecycle_msgs</depend>

--- a/microstrain_inertial_driver/src/microstrain_inertial_driver.cpp
+++ b/microstrain_inertial_driver/src/microstrain_inertial_driver.cpp
@@ -219,6 +219,10 @@ bool Microstrain::activate_node()
   if(publishers_.rtk_pub_)
     publishers_.rtk_pub_->on_activate();
   
+  //NMEA publisher
+  if (publishers_.nmea_sentence_pub_)
+    publishers_.nmea_sentence_pub_->on_activate();
+
   //Filter Publishers
   if(publishers_.filter_status_pub_)
     publishers_.filter_status_pub_->on_activate();

--- a/microstrain_inertial_driver/src/microstrain_inertial_driver.cpp
+++ b/microstrain_inertial_driver/src/microstrain_inertial_driver.cpp
@@ -171,10 +171,18 @@ bool Microstrain::activate_node()
   }
 
   // Start a timer around a wrapper function to catch errors
-  parsing_timer_ = create_timer<Microstrain>(node_, timer_update_rate_hz_,
-      &Microstrain::parse_and_publish_wrapper, this);
+  main_parsing_timer_ = create_timer<Microstrain>(node_, timer_update_rate_hz_,
+      &Microstrain::parse_and_publish_main_wrapper, this);
   device_status_timer_ = create_timer<Microstrain>(node_, 1.0,
       &Microstrain::device_status_wrapper, this);
+
+  // Start the aux timer if we were requested to do so
+  if (config_.supports_rtk_ && config_.publish_nmea_)
+  {
+    RCLCPP_INFO(this->get_logger(), "Starting aux port parsing");
+    aux_parsing_timer_ = create_timer<Microstrain>(node_, 2.0,
+        &Microstrain::parse_and_publish_aux_wrapper, this);
+  }
 
   //Activate publishers
   if (publishers_.device_status_pub_)
@@ -382,16 +390,30 @@ bool Microstrain::shutdown_or_cleanup_node()
   return true;
 }
 
-void Microstrain::parse_and_publish_wrapper()
+void Microstrain::parse_and_publish_main_wrapper()
 {
   // call the parsing function in a try catch block so we can transition the state instead of crashing when an error happens
   try
   {
-    parseAndPublish();
+    parseAndPublishMain();
   }
   catch (const std::exception& e)
   {
-    RCLCPP_ERROR(this->get_logger(), "Error during processing: %s", e.what());
+    RCLCPP_ERROR(this->get_logger(), "Error during main processing: %s", e.what());
+    handle_exception();
+  }
+}
+
+void Microstrain::parse_and_publish_aux_wrapper()
+{
+  // call the parsing function in a try catch block so we can transition the state instead of crashing when an error happens
+  try
+  {
+    parseAndPublishAux();
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(this->get_logger(), "Error during aux processing: %s", e.what());
     handle_exception();
   }
 }


### PR DESCRIPTION
* Adds some convenience packages to development docker image to make bash completion and file editting easier
* Fixes `Makefile` to work with ROS2
* Adds convenience udev rules which will map the last device connected to `/dev/microstrain_main` for the main port, `/dev/microstrain_aux` for the aux port, and `/dev/microstrain_rtk` for RTK devices. This is convenient for robotics platforms which will often only have a single device to not have to know the specific device serial in order to use udev symlinks.
* Implements LORD-MicroStrain/microstrain_inertial_driver_common#2 for ROS2