### PR TITLE
ROS Check supported aiding measurements

### DIFF
--- a/microstrain_inertial_driver/CMakeLists.txt
+++ b/microstrain_inertial_driver/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 
 # Download and install MSCL
 include(${COMMON_DIR}/cmake/download_mscl.cmake)
-download_mscl(VERSION "63.1.0")
+download_mscl(VERSION "64.2.2")
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)


### PR DESCRIPTION
* Updates MSCL version to `64.2.2`
* Checks if the device supports the requested aiding measurements before enabling/disabling
* Depends on LORD-MicroStrain/microstrain_inertial_driver_common#18