### PR TITLE
wait for successful configure to send activate transition

### DIFF
--- a/microstrain_inertial_driver/launch/microstrain_launch.py
+++ b/microstrain_inertial_driver/launch/microstrain_launch.py
@@ -112,7 +112,6 @@ def generate_launch_description():
       entities=[
         activate_emit_event
       ],
-      handle_once=True,  # Don't automatically activate after the first time
     )
   ))
   return LaunchDescription(launch_description)

--- a/microstrain_inertial_driver/launch/microstrain_launch.py
+++ b/microstrain_inertial_driver/launch/microstrain_launch.py
@@ -88,14 +88,14 @@ def generate_launch_description():
   )
 
   # Optional configure and activate steps
-  config_event = EmitEvent(
+  config_emit_event = EmitEvent(
     event = ChangeState(
       lifecycle_node_matcher = matches_action(microstrain_node),
       transition_id          = Transition.TRANSITION_CONFIGURE
     ),
     condition = LaunchConfigurationEquals('configure', 'true')
   )
-  activate_event = EmitEvent(
+  activate_emit_event = EmitEvent(
     event = ChangeState(
       lifecycle_node_matcher = matches_action(microstrain_node),
       transition_id          = Transition.TRANSITION_ACTIVATE
@@ -104,13 +104,13 @@ def generate_launch_description():
   )
 
   launch_description.append(microstrain_node)
-  launch_description.append(config_event)
+  launch_description.append(config_emit_event)
   launch_description.append(RegisterEventHandler(
     event_handler=OnStateTransition(
       target_lifecycle_node=microstrain_node,
       goal_state="inactive",
       entities=[
-        activate_event
+        activate_emit_event
       ],
     )
   ))

--- a/microstrain_inertial_driver/launch/microstrain_launch.py
+++ b/microstrain_inertial_driver/launch/microstrain_launch.py
@@ -110,9 +110,7 @@ def generate_launch_description():
       target_lifecycle_node=microstrain_node,
       goal_state="inactive",
       entities=[
-        EmitEvent(
-          event=activate_event
-        )
+        activate_event
       ],
     )
   ))

--- a/microstrain_inertial_driver/launch/microstrain_launch.py
+++ b/microstrain_inertial_driver/launch/microstrain_launch.py
@@ -112,6 +112,7 @@ def generate_launch_description():
       entities=[
         activate_emit_event
       ],
+      handle_once=True,  # Don't automatically activate after the first time
     )
   ))
   return LaunchDescription(launch_description)

--- a/microstrain_inertial_driver/launch/microstrain_launch.py
+++ b/microstrain_inertial_driver/launch/microstrain_launch.py
@@ -5,12 +5,13 @@
 import os
 import yaml
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, EmitEvent
+from launch.actions import DeclareLaunchArgument, EmitEvent, RegisterEventHandler
 from launch.conditions import LaunchConfigurationEquals
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch.events import matches_action
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
+from launch_ros.event_handlers.on_state_transition import OnStateTransition
 
 from lifecycle_msgs.msg import Transition
 from ament_index_python.packages import get_package_share_directory
@@ -104,7 +105,17 @@ def generate_launch_description():
 
   launch_description.append(microstrain_node)
   launch_description.append(config_event)
-  launch_description.append(activate_event)
+  launch_description.append(RegisterEventHandler(
+    event_handler=OnStateTransition(
+      target_lifecycle_node=microstrain_node,
+      goal_state="inactive",
+      entities=[
+        EmitEvent(
+          event=activate_event
+        )
+      ],
+    )
+  ))
   return LaunchDescription(launch_description)
   
 


### PR DESCRIPTION
Rather than relying on the launch action ordering, this explicitly waits for the configure transition to succeed before sending the activate event. This also avoids spurious errors when configure fails (such as when the device is disconnected).