### PR TITLE
Updates to use the version of create_timer supported in ROS rolling

### DIFF
--- a/microstrain_inertial_driver/include/microstrain_inertial_driver/microstrain_inertial_driver.h
+++ b/microstrain_inertial_driver/include/microstrain_inertial_driver/microstrain_inertial_driver.h
@@ -24,6 +24,7 @@
 #include <time.h>
 #include <iostream>
 #include <fstream>
+#include <functional>
 
 #include "microstrain_inertial_driver_common/microstrain_node_base.h"
 
@@ -61,8 +62,22 @@ class Microstrain : public rclcpp_lifecycle::LifecycleNode, public MicrostrainNo
   void device_status_wrapper();
 
  private:
+
+  template<typename Object, void (Object::*Callback)()>
+  RosTimerType create_timer_wrapper(double rate_hz);
+
   void handle_exception();
 }; //Microstrain class
+
+template<typename Object, void (Object::*Callback)()>
+RosTimerType Microstrain::create_timer_wrapper(double rate_hz)
+{
+#ifdef MICROSTRAIN_ROLLING
+  return create_timer(std::chrono::duration<double, std::milli>(1 / rate_hz), std::bind(Callback, this));
+#else
+  return create_timer<Microstrain>(node_, rate_hz, Callback, this);
+#endif
+}
 
 } // namespace microstrain
 

--- a/microstrain_inertial_driver/src/microstrain_inertial_driver.cpp
+++ b/microstrain_inertial_driver/src/microstrain_inertial_driver.cpp
@@ -179,22 +179,18 @@ bool Microstrain::activate_node()
   }
 
   // Start a timer around a wrapper function to catch errors
-  main_parsing_timer_ = create_timer<Microstrain>(node_, timer_update_rate_hz_,
-      &Microstrain::parse_and_publish_main_wrapper, this);
-  device_status_timer_ = create_timer<Microstrain>(node_, 1.0,
-      &Microstrain::device_status_wrapper, this);
+  main_parsing_timer_ = create_timer_wrapper<Microstrain, &Microstrain::parse_and_publish_main_wrapper>(timer_update_rate_hz_);
+  device_status_timer_ = create_timer_wrapper<Microstrain, &Microstrain::device_status_wrapper>(1.0);
 
   // Start a timer to log debug information if debug is enabled
   if (config_.debug_)
-    log_debug_timer_ = create_timer<Microstrain>(node_, 1.0,
-        &Microstrain::logDeviceDebugInfo, this);
+    log_debug_timer_ = create_timer_wrapper<MicrostrainNodeBase, &MicrostrainNodeBase::logDeviceDebugInfo>(1.0);
 
   // Start the aux timer if we were requested to do so
   if (config_.supports_rtk_ && config_.publish_nmea_)
   {
     RCLCPP_INFO(this->get_logger(), "Starting aux port parsing");
-    aux_parsing_timer_ = create_timer<Microstrain>(node_, 2.0,
-        &Microstrain::parse_and_publish_aux_wrapper, this);
+    aux_parsing_timer_ = create_timer_wrapper<Microstrain, &Microstrain::parse_and_publish_aux_wrapper>(2.0);
   }
 
   //Activate publishers


### PR DESCRIPTION
Should fix failing ROS rolling builds