### PR TITLE
Validates that all publishers are documented on the wiki for ROS

### DIFF
--- a/microstrain_inertial_driver/CMakeLists.txt
+++ b/microstrain_inertial_driver/CMakeLists.txt
@@ -251,3 +251,9 @@ get_target_property(ROSLINT_SOURCES ${PROJECT_NAME} SOURCES)
 roslint_cpp(${ROSLINT_SOURCES})
 
 roslint_add_test()
+
+# Make sure that the wiki document is up to date
+add_test(
+  NAME wiki_publishers
+  COMMAND ${CMAKE_COMMAND} -E env ${COMMON_DIR}/tools/check-wiki-publishers.sh
+)


### PR DESCRIPTION
* Also fixes the `gnss*/time_ref` topics to actually publish
* Depends on LORD-MicroStrain/microstrain_inertial_driver_common#38