### PR TITLE
ROS: Uses rtcm_msgs/Message instead of mavros_msgs/RTCM

### DIFF
--- a/microstrain_inertial_driver/CMakeLists.txt
+++ b/microstrain_inertial_driver/CMakeLists.txt
@@ -80,7 +80,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   nav_msgs
   nmea_msgs
-  mavros_msgs
+  rtcm_msgs
   roscpp
   sensor_msgs
   std_msgs
@@ -116,7 +116,7 @@ catkin_package(
     sensor_msgs
     nav_msgs
     nmea_msgs
-    mavros_msgs
+    rtcm_msgs
     message_runtime
     microstrain_inertial_msgs
 )

--- a/microstrain_inertial_driver/package.xml
+++ b/microstrain_inertial_driver/package.xml
@@ -24,7 +24,7 @@
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>nmea_msgs</depend>
-  <depend>mavros_msgs</depend>
+  <depend>rtcm_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   
   <depend>microstrain_inertial_msgs</depend>


### PR DESCRIPTION
Depends on LORD-MicroStrain/microstrain_inertial_driver_common#54