### PR TITLE
Add dummy inertias for Gazebo simulation

### DIFF
--- a/microstrain_inertial_description/urdf/cv7.urdf.xacro
+++ b/microstrain_inertial_description/urdf/cv7.urdf.xacro
@@ -1,5 +1,14 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:macro name="dummy_inertia">
+    <inertial>
+      <mass value="0.001" />
+      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+               iyy="0.0001" iyz="0.0"
+               izz="0.0001" />
+    </inertial>
+  </xacro:macro>
+
   <xacro:macro name="cv7" params="name parent *origin">
     <material name="cv7_material">
       <color rgba="${80/255} ${81/255} ${85/255} 1" />
@@ -13,9 +22,11 @@
         </geometry>
         <material name="cv7_material"/>
       </visual>
+      <xacro:dummy_inertia/>
     </link>
 
     <link name="${name}">
+      <xacro:dummy_inertia/>
     </link>
 
     <!-- This joint handles the center of the CV7, but measurements will not be produced WRT to this, it is just easier to place on robots -->

--- a/microstrain_inertial_driver/CMakeLists.txt
+++ b/microstrain_inertial_driver/CMakeLists.txt
@@ -97,13 +97,17 @@ find_package(catkin REQUIRED COMPONENTS
   microstrain_inertial_msgs
 )
 
-# Find some less ROS-y packages
-list(APPEND CMAKE_MODULE_PATH "/usr/share/cmake/geographiclib/")
-find_package(Eigen3 REQUIRED)
-find_package(GeographicLib REQUIRED)
+# GeographicLib
+include(FetchContent)
+FetchContent_Declare(
+  GeographicLib
+  GIT_REPOSITORY https://github.com/geographiclib/geographiclib.git
+  GIT_TAG v2.3
+)
+FetchContent_MakeAvailable(GeographicLib)
 
-# We want to use the static library for libgeographic, but it doesn't seem to find it for us, so substitute it here
-string(REGEX REPLACE "[.]so[^\\/\\s]*$" ".a" GeographicLib_LIBRARIES ${GeographicLib_LIBRARIES})
+# Find some less ROS-y packages
+find_package(Eigen3 REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -143,7 +147,6 @@ include_directories(
   ${COMMON_DIR}/include
   ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
-  ${GeographicLib_INCLUDE_DIRS}
 )
 
 set(LIB_SRC_FILES
@@ -224,7 +227,7 @@ target_link_libraries(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}_node
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}
-  ${GeographicLib_LIBRARIES}
+  GeographicLib
 )
 
 #############

--- a/microstrain_inertial_driver/package.xml
+++ b/microstrain_inertial_driver/package.xml
@@ -26,12 +26,12 @@
   <depend>nmea_msgs</depend>
   <depend>rtcm_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
-  
+
   <depend>microstrain_inertial_msgs</depend>
 
   <!-- Static or header only library deps -->
   <build_depend>eigen</build_depend>
-  <build_depend>geographiclib</build_depend>
+  <!-- <build_depend>geographiclib</build_depend> -->
 
   <build_depend>message_generation</build_depend>
   <build_depend>roslint</build_depend>


### PR DESCRIPTION
Inertias are required to launch a Gazebo simulation using the URDF files from `microstrain_inertial_description`. This code can also be added to your robot:

```xml
<!-- Parker IMU -->
<gazebo reference="parker_center_joint">
  <preserveFixedJoint>true</preserveFixedJoint>
</gazebo>
<gazebo reference="parker_joint">
  <preserveFixedJoint>true</preserveFixedJoint>
</gazebo>
<gazebo reference="parker">
  <sensor name="parker_imu" type="imu">
    <pose>0 0 0 0 0 0</pose>
    <always_on>true</always_on>
    <update_rate>0</update_rate>
    <visualize>false</visualize>
    <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
      <topicName>/parker/imu</topicName>
      <bodyName>parker</bodyName>
      <updateRateHZ>50.0</updateRateHZ>
      <xyzOffset>0 0 0</xyzOffset>
      <gaussianNoise>0</gaussianNoise>
      <rpyOffset>0 0 0</rpyOffset>
      <frameName>parker</frameName>
      <initialOrientationAsReference>false</initialOrientationAsReference>
    </plugin>
  </sensor>
</gazebo>
```